### PR TITLE
Parser: In PEG, always check for None not empty

### DIFF
--- a/notebooks/Parser.ipynb
+++ b/notebooks/Parser.ipynb
@@ -1543,7 +1543,7 @@
     "                return at, None\n",
     "        for rule in self.cgrammar[key]:\n",
     "            to, res = self.unify_rule(rule, text, at)\n",
-    "            if res:\n",
+    "            if res is not None:\n",
     "                return (to, (key, res))\n",
     "        return 0, None"
    ]
@@ -1683,7 +1683,7 @@
     "                return at, None\n",
     "        for rule in self.cgrammar[key]:\n",
     "            to, res = self.unify_rule(rule, text, at)\n",
-    "            if res:\n",
+    "            if res is not None:\n",
     "                return (to, (key, res))\n",
     "        return 0, None"
    ]


### PR DESCRIPTION
Previously, in PEG, the check was whether the return value was
empty. This caused an error when we were trying to match empty
string. Instead, one should always check for `None` which is
the correct value.